### PR TITLE
Cobigen references fixed to new submodule and repository URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 [submodule "devon4net.wiki"]
 	path = devon4net.wiki
 	url = https://github.com/devonfw/devon4net.wiki.git
-[submodule "tools-cobigen.wiki"]
-	path = tools-cobigen.wiki
-	url = https://github.com/devonfw/tools-cobigen.wiki.git
 [submodule "devon4j.wiki"]
 	path = devon4j.wiki
 	url = https://github.com/devonfw/devon4j.wiki.git

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.exclude": {
+        "**/.classpath": true,
+        "**/.project": true,
+        "**/.settings": true,
+        "**/.factorypath": true
+    }
+}

--- a/general/release-notes-version-2.1.asciidoc
+++ b/general/release-notes-version-2.1.asciidoc
@@ -61,7 +61,7 @@ The new version of devonfw contains more elaborate and updated documentation abo
 
 The CobiGen incremental code generator released in the previous version contained a regression which has now been fixed. Generating services in Batch mode whereby a package can be given as an input, using all Entities contained in that package, works again as expected.
 
-For more information see: https://github.com/devonfw/tools-cobigen/wiki[The CobiGen documentation] and the corresponding change in the https://github.com/devonfw/devon/wiki/getting-started-Cobigen[devonfw Guide]
+For more information see: https://github.com/devonfw/cobigen/wiki[The CobiGen documentation] and the corresponding change in the https://github.com/devonfw/devon/wiki/getting-started-Cobigen[devonfw Guide]
 
 === Devcon enhancements
 
@@ -100,7 +100,7 @@ Currently we support Sencha Ext JS with support for Angular 2 coming soon. The c
 
 Cobigen can now also be used for code-generation within the context of an engagement. It is easily extensible and the process of how to extend it for your own project is well documented. This becomes already worthwhile ("delivers ROI") when having 5+ identical elements within the project. 
 
-For more information see: https://github.com/devonfw/tools-cobigen/wiki[The Cobigen documentation] and the corresponding changer in the https://github.com/devonfw/devon/wiki/getting-started-Cobigen[devonfw Guide] and 
+For more information see: https://github.com/devonfw/cobigen/wiki[The Cobigen documentation] and the corresponding changer in the https://github.com/devonfw/devon/wiki/getting-started-Cobigen[devonfw Guide] and 
 
 === Angular 2
 

--- a/general/release-notes-version-2.2.asciidoc
+++ b/general/release-notes-version-2.2.asciidoc
@@ -72,7 +72,7 @@ Major changes in this release:
 * CI integration improved to integrate with GitHub for more valuable feedback
 
 
-See: https://github.com/devonfw/tools-cobigen/releases
+See: https://github.com/devonfw/cobigen/releases
 
 == MyThaiStar: New Restaurant Example, reference implementation & Methodology showcase
 

--- a/general/release-notes-version-2.3.asciidoc
+++ b/general/release-notes-version-2.3.asciidoc
@@ -81,8 +81,8 @@ See: https://github.com/oasp/oasp4j/pull/589/commits
 
 A new version of Cobigen has been included. New features include: 
  
-* Swagger/Yaml Plugin for CobiGen. CobiGen is able to read a swagger definition file that follows the OpenAPI 3.0 spec and generate code. A preliminary release was already included in 2.2.1 but the current version is much more mature and stable. See: https://github.com/devonfw/tools-cobigen/wiki/howto_openapi_generation
-* Integration of CobiGen into Maven build process. This already existed but has been improved. It consists mainly of documentation + better log output and bug fixes. See: https://github.com/devonfw/tools-cobigen/wiki/cobigen-maven_configuration
+* Swagger/Yaml Plugin for CobiGen. CobiGen is able to read a swagger definition file that follows the OpenAPI 3.0 spec and generate code. A preliminary release was already included in 2.2.1 but the current version is much more mature and stable. See: https://github.com/devonfw/cobigen/wiki/howto_openapi_generation
+* Integration of CobiGen into Maven build process. This already existed but has been improved. It consists mainly of documentation + better log output and bug fixes. See: https://github.com/devonfw/cobigen/wiki/cobigen-maven_configuration
 * CobiGen Ionic CRUD App generation based on https://github.com/oasp/oasp4js-ionic-application-template
 * Cobigen_Templates project and docs updated
 * Bugfixes and Hardening

--- a/general/release-notes-version-3.1.asciidoc
+++ b/general/release-notes-version-3.1.asciidoc
@@ -19,7 +19,7 @@ This is now possible as we have established a new workflow and rules during deve
 
 image::images/documentation_workflow.png[link="images/documentation_workflow.png"]
 
-This release includes the very first version of the new CobiGen CLI. Now using commands, you will be able to generate code the same way as you do with Eclipse. This means that you can use CobiGen on other IDEs like Visual Studio Code or IntelliJ. Please take a look at https://github.com/devonfw/tools-cobigen/wiki/howto_Cobigen-CLI-generation for more info.
+This release includes the very first version of the new CobiGen CLI. Now using commands, you will be able to generate code the same way as you do with Eclipse. This means that you can use CobiGen on other IDEs like Visual Studio Code or IntelliJ. Please take a look at https://github.com/devonfw/cobigen/wiki/howto_Cobigen-CLI-generation for more info.
 
 The devonfw-shop-floor project has got a lot of updates in order to make even easier the creation of devonfw projects with CICD pipelines that run on the Production Line, deploy on Red Hat OpenShift Clusters and in general Docker environments. See the details below. 
 

--- a/general/release-notes-version-3.2.asciidoc
+++ b/general/release-notes-version-3.2.asciidoc
@@ -198,12 +198,12 @@ The following changes have been incorporated in devon4node:
 === CobiGen
 
 * CobiGen core new features:
-** CobiGen CLI: Update command implemented. Now you will be able to update easily all your CobiGen plug-ins and templates inside the CLI. Please take a look into the https://github.com/devonfw/tools-cobigen/wiki/howto_Cobigen-CLI-generation[documentation] for more info.
+** CobiGen CLI: Update command implemented. Now you will be able to update easily all your CobiGen plug-ins and templates inside the CLI. Please take a look into the https://github.com/devonfw/cobigen/wiki/howto_Cobigen-CLI-generation[documentation] for more info.
 *** CobiGen CLI is now JDK11 compatible.
 *** CobiGen CLI commandlet for devonfw-ide has been added. You can use it to setup easily your CLI and to run CobiGen related commands.
 *** Added a version provider so that you will be able to know all the CobiGen plug-ins versions.
 *** Added a process bar when the CLI is downloading the CobiGen plug-ins.
-** CobiGen refactoring finished: With this refactoring we have been able to decouple CobiGen completely from the target and input language. This facilitates the creation of parsers and mergers for any language. For more information please take a look https://github.com/devonfw/tools-cobigen/wiki/howto_create-external-plugin[here].
+** CobiGen refactoring finished: With this refactoring we have been able to decouple CobiGen completely from the target and input language. This facilitates the creation of parsers and mergers for any language. For more information please take a look https://github.com/devonfw/cobigen/wiki/howto_create-external-plugin[here].
 *** New TypeScript input reader: We are now able to parse any TypeScript class and generate code using the parsed information. We currently use https://github.com/typeorm/typeorm/blob/master/docs/entities.md#what-is-entity[TypeORM] entities as a base for generation.
 ** Improving CobiGen templates: 
 *** Updated devon4ng-NgRx templates to NgRx 8.

--- a/master.asciidoc
+++ b/master.asciidoc
@@ -31,7 +31,7 @@ include::cicdgen.wiki/master-cicdgen[leveloffset=0]
 
 include::production-line.wiki/master-production-line[leveloffset=0]
 
-include::tools-cobigen.wiki/master-cobigen[leveloffset=0]
+include::cobigen.wiki/master-cobigen[leveloffset=0]
 
 include::mrchecker.wiki/master-mrchecker[leveloffset=0]
 


### PR DESCRIPTION
All the references used in the devonfw guide to CobiGen have been updated to the new repository and submodule folder. 