### PR TITLE
devonfw shop floor renamed to shop floor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "my-thai-star.wiki"]
 	path = my-thai-star.wiki
 	url = https://github.com/devonfw/my-thai-star.wiki.git
-[submodule "devonfw-shop-floor.wiki"]
-	path = devonfw-shop-floor.wiki
-	url = https://github.com/devonfw/devonfw-shop-floor.wiki.git
 [submodule "cicdgen.wiki"]
 	path = cicdgen.wiki
 	url = https://github.com/devonfw/cicdgen.wiki.git

--- a/master.asciidoc
+++ b/master.asciidoc
@@ -25,7 +25,7 @@ include::devon4node.wiki/master-devon4node[leveloffset=0]
 
 include::general/db/master-database[leveloffset=0]
 
-include::devonfw-shop-floor.wiki/master-devonfw-shop-floor[leveloffset=0]
+include::shop-floor.wiki/master-devonfw-shop-floor[leveloffset=0]
 
 include::cicdgen.wiki/master-cicdgen[leveloffset=0]
 


### PR DESCRIPTION
The submodule of its documentation has been renamed automatically, so the master doc and git submodules configuration needed to be fixed. 