### PR TITLE
updated docgen to 2021.04.001

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>com.devonfw.tools</groupId>
     <artifactId>devonfw-docgen-pdf</artifactId>
-    <version>5.0.0</version>
+    <version>2021.04.001</version>
   </parent>
 
   <properties>


### PR DESCRIPTION
update docgen as a very outdated and buggy version of docgen is used so far with many broken links in the website.