### PR TITLE
feat: Remove Architecture guidelines

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -78,8 +78,4 @@
 	path = devon4ts.wiki
 	url = https://github.com/devonfw/devon4ts.wiki.git
 	shallow = true
-[submodule "architecture-guidelines.wiki"]
-	path = architecture-guidelines.wiki
-	url = https://github.com/devonfw/architecture-guidelines.wiki.git
-	shallow = true
 	


### PR DESCRIPTION
Remove the empty architecture guidelines repository from the list of submodules